### PR TITLE
ci: automate bot releases and Renovate merges

### DIFF
--- a/.github/workflows/renovate-approval.yaml
+++ b/.github/workflows/renovate-approval.yaml
@@ -1,0 +1,87 @@
+name: Renovate Approval
+
+on:
+  workflow_run:
+    workflows:
+      - PR Validation
+      - CodeQL
+    types:
+      - completed
+
+jobs:
+  approve:
+    name: Approve eligible Renovate PRs
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Create actual-assist bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.ACTUAL_ASSIST_BOT_ID }}
+          private-key: ${{ secrets.ACTUAL_ASSIST_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+          permission-pull-requests: write
+
+      - name: Approve eligible Renovate pull requests
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          pull_requests=$(gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "/repos/${REPOSITORY}/commits/${WORKFLOW_SHA}/pulls" \
+            --jq '.[].number')
+
+          if [[ -z "${pull_requests}" ]]; then
+            echo "No pull requests are associated with this workflow run."
+            exit 0
+          fi
+
+          while IFS= read -r pr_number; do
+            pr=$(gh pr view "${pr_number}" --repo "${REPOSITORY}" \
+              --json author,baseRefName,headRefName,labels,reviews,statusCheckRollup)
+
+            if ! jq -e '
+              .author.login == "renovate[bot]" or .author.login == "app/renovate"
+            ' <<<"${pr}" >/dev/null; then
+              echo "Skipping #${pr_number}: not authored by Renovate."
+              continue
+            fi
+
+            if ! jq -e '
+              .baseRefName == "main" and
+              (.headRefName | startswith("renovate/")) and
+              any(.labels[]?; .name == "renovate-automerge")
+            ' <<<"${pr}" >/dev/null; then
+              echo "Skipping #${pr_number}: not an eligible Renovate PR."
+              continue
+            fi
+
+            if ! jq -e '
+              (.statusCheckRollup | length > 0) and
+              all(.statusCheckRollup[];
+                .name != null and
+                .status == "COMPLETED" and
+                .conclusion == "SUCCESS")
+            ' <<<"${pr}" >/dev/null; then
+              echo "Skipping #${pr_number}: required checks are not all successful."
+              continue
+            fi
+
+            if jq -e 'any(.reviews[]?; .user.login == "actual-assist-bot[bot]" and .state == "APPROVED")' <<<"${pr}" >/dev/null; then
+              echo "Skipping #${pr_number}: already approved by actual-assist-bot."
+              continue
+            fi
+
+            gh pr review "${pr_number}" --repo "${REPOSITORY}" \
+              --approve \
+              --body "Automated approval: Renovate PR and all reported checks passed."
+          done <<<"${pull_requests}"

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (vX.Y.Z with optional pre-release/build)"
+        description: 'Release version (vX.Y.Z with optional pre-release/build)'
         required: true
 
 jobs:
@@ -14,9 +14,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Create actual-assist bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.ACTUAL_ASSIST_BOT_ID }}
+          private-key: ${{ secrets.ACTUAL_ASSIST_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Validate version input
         id: validate
@@ -83,13 +93,15 @@ jobs:
 
       - name: Commit and tag
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "actual-assist-bot[bot]"
+          git config user.email "actual-assist-bot[bot]@users.noreply.github.com"
           git add package.json package-lock.json charts/actual-assist/Chart.yaml
           git commit -m "chore(release): ${{ steps.validate.outputs.version }}"
           git tag "${{ steps.validate.outputs.version }}"
 
       - name: Push commit and tag
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git push origin HEAD
           git push origin "${{ steps.validate.outputs.version }}"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "prConcurrentLimit": 5,
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "description": "Auto-merge patch and minor dependency updates",
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "labels": ["renovate-automerge"]
+    },
+    {
+      "description": "Auto-merge GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "labels": ["renovate-automerge"]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- authenticate the version workflow with the actual-assist bot GitHub App;
- configure Renovate to automerge patch/minor dependency and GitHub Actions updates;
- approve eligible Renovate PRs only after all checks pass.

## Repository settings

The `main` ruleset now requires `PR Validation Summary` and `CodeQL`. Renovate remains outside the bypass list; the existing actual-assist bot bypass is preserved for release pushes.

## Validation

- `npm test` — 50 tests passed
- `npm run lint` — passed
- Prettier checks — passed
- `git diff --check` — passed

Unrelated working-tree changes were intentionally excluded.
