### PR TITLE
fix(deps): update Actual API to 26.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -436,6 +436,29 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
@@ -7562,13 +7585,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/ts-pattern": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
-      "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -7576,6 +7592,13 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/ts-pattern": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
+      "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.23.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "actual-assist",
       "version": "0.6.0",
       "dependencies": {
-        "@actual-app/api": "26.8.0",
+        "@actual-app/api": "26.8.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@google/genai": "^2.15.0",
@@ -63,12 +63,12 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "26.8.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.8.0.tgz",
-      "integrity": "sha512-hFtepJjD9pmWo7eY53mvZ4AACEENUYCW4v0EYmYS/BhxTVMY5MjzcsW7GXwOE2iO9tJLJmSBkORWTB6rDNte2Q==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.8.1.tgz",
+      "integrity": "sha512-FpOjTdbXEUlph1pElNANT/y2TwNn3vGbR/4SRRtic6x2kZIrrKZBCx4+X5/GobVNLPGJX66p6tVcki41nqpPZA==",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/core": "26.8.0",
+        "@actual-app/core": "26.8.1",
         "@actual-app/crdt": "3.1.1",
         "better-sqlite3": "^12.11.1",
         "compare-versions": "^6.1.1",
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/@actual-app/core": {
-      "version": "26.8.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.8.0.tgz",
-      "integrity": "sha512-TP3Bw86JVshli5lccr/RqOaLIh2KLGE+Rtz4iTJnML7hFsSF1261db6QqntrSwvmxyTYqbxQR/2EQua2Uc20VQ==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.8.1.tgz",
+      "integrity": "sha512-1uvhHqZ4QeBeOkEzLr+OAvRKQWSZr1E+oO32V2v4HgqwUF1MUkHtUZqEaf7WQswaF8hNNTI0GeL2goVbTJu6xg==",
       "license": "ISC",
       "dependencies": {
         "@jlongster/sql.js": "^1.6.7",
@@ -434,6 +434,17 @@
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -2311,6 +2322,51 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
@@ -7512,6 +7568,14 @@
       "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.23.8",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
-    "@actual-app/api": "26.8.0",
+    "@actual-app/api": "26.8.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@google/genai": "^2.15.0",


### PR DESCRIPTION
Updates @actual-app/api from 26.8.0 to 26.8.1 and refreshes the package lockfile, including @actual-app/core.

Supersedes #132.

Checks: npm test && npm run lint